### PR TITLE
Use `smartcache` prefix on scheduled event action

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -149,7 +149,7 @@ function queue_invalidate_urls( array $urls ) : void {
 	if ( ! $urls ) {
 		return;
 	}
-	wp_schedule_single_event( time() + 5, 'logcache.invalidate_urls', [ $urls ] );
+	wp_schedule_single_event( time() + 5, 'smartcache.invalidate_urls', [ $urls ] );
 }
 
 /**


### PR DESCRIPTION
This fixes an instance of what appears to be a misspelled action hook (logcache.invalidate_urls rather than longcache.invalidate_urls) that was not caught in the rename.

There does not appear to be any code handling this `logcache.invalidate_urls` event hook, so it seems okay to change. (I think events are just going off into the ether right now)